### PR TITLE
Remove jstl tag library

### DIFF
--- a/component/authenticator/src/main/resources/pwd-reset.jsp
+++ b/component/authenticator/src/main/resources/pwd-reset.jsp
@@ -22,10 +22,8 @@
 <%@ page import="java.util.Map" %>
 <%@page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.TenantDataManager" %>
 
-<fmt:bundle basename="org.wso2.carbon.identity.application.authentication.endpoint.i18n.Resources">
 
     <%
         request.getSession().invalidate();
@@ -181,4 +179,3 @@
     <script src="libs/bootstrap_3.3.5/js/bootstrap.min.js"></script>
     </body>
     </html>
-</fmt:bundle>


### PR DESCRIPTION
## Purpose
> Fix [https://github.com/wso2/product-is/issues/3549](https://github.com/wso2/product-is/issues/3549)

## Approach
> Removing JSTL tag library from pwd-reset.jsp file as it doesn't have localization support anyway.