### PR TITLE
Fix cyclic call for get connector default properties

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordChangeHandler.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordChangeHandler.java
@@ -129,6 +129,12 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
         if (passwordExpiryInDays == null) {     // To avoid null pointer exceptions if user had not added module config
             passwordExpiryInDays =
                     Integer.toString(PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS_DEFAULT_VALUE);
+            if (log.isDebugEnabled()) {
+                log.debug("Using the default property value: " +
+                        PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS_DEFAULT_VALUE + " for the " +
+                        "configuration: " + PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS
+                        + " because no module configuration is present.");
+            }
         }
         properties.setProperty(PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS, passwordExpiryInDays);
 
@@ -138,6 +144,12 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
         if (enableDataPublishing == null) {     // To avoid null pointer exceptions if user had not added module config
             enableDataPublishing =
                     Boolean.toString(PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS_DEFAULT_VALUE);
+            if (log.isDebugEnabled()) {
+                log.debug("Using the default property value: " +
+                        PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS_DEFAULT_VALUE + " for the "
+                        + "configuration: " + PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS
+                        + " because no module configuration is present.");
+            }
         }
         properties.setProperty(PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS,
                 enableDataPublishing);
@@ -148,6 +160,12 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
         if (priorReminderTimeInDays == null) {   // To avoid null pointer exceptions if user had not added module config
             priorReminderTimeInDays =
                     Integer.toString(PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_NOTICE_TIME_IN_DAYS_DEFAULT_VALUE);
+            if (log.isDebugEnabled()) {
+                log.debug("Using the default property value: " +
+                        PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_NOTICE_TIME_IN_DAYS_DEFAULT_VALUE + " for the "
+                        + "configuration: " + PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS
+                        + " because no module configuration is present.");
+            }
         }
         properties.setProperty(PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS,
                 priorReminderTimeInDays);

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordPolicyUtilsTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordPolicyUtilsTest.java
@@ -55,20 +55,4 @@ public class PasswordPolicyUtilsTest {
         Assert.assertEquals(passwordExpiryPropertyNames[2],
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS);
     }
-
-    @Test
-    public void testGetIdentityEventProperty() throws IdentityGovernanceException {
-        Property[] properties = new Property[1];
-        Property property = new Property();
-        property.setName("test");
-        property.setValue("testValue");
-        properties[0] = property;
-
-        IdentityGovernanceService identityGovernanceService = mock(IdentityGovernanceService.class);
-        when(identityGovernanceService.getConfiguration(Mockito.any(String[].class), Mockito.eq(TENANT_DOMAIN)))
-                .thenReturn(properties);
-        PasswordPolicyDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
-
-        Assert.assertEquals(PasswordPolicyUtils.getIdentityEventProperty(TENANT_DOMAIN, "test"), "testValue");
-    }
 }


### PR DESCRIPTION
## Purpose
> * Honoring resident IPD configurations in connector default configurations can create a cyclic call when connector configs are not present in the resident IDP. Ex: During server startup.
> * Identity governance service is itself dependent on the connector while getting connectorConfigs. Therefore honoring resident IDP configs needs only to be handled in the identity governance service.

## Goals
> * Retrieve connector default configurations only from the event-properties file.
> * Remove redundant test case with governance service.