### PR TITLE
Mark connector as deprecated and do a major version bump

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.passwordpolicy</artifactId>
-        <version>1.0.30-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.extension.identity.authenticator.passwordpolicy.connector</artifactId>
-    <version>1.0.30-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon Extension - Password Policy - Authenticator</name>
     <url>http://wso2.org</url>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
@@ -42,7 +42,7 @@ public class PasswordPolicyConstants {
             "org.wso2.carbon.identity.policy.password.PendingNotifications:1.0.0";
     public static final String PASSWORD_CHANGE_EVENT_HANDLER_NAME = "passwordExpiry";
 
-    public static final String CONNECTOR_CONFIG_FRIENDLY_NAME = "Password Expiry";
+    public static final String CONNECTOR_CONFIG_FRIENDLY_NAME = "[Deprecated] Password Expiry";
     public static final String CONNECTOR_CONFIG_CATEGORY = "Password Policies";
     public static final String CONNECTOR_CONFIG_SUB_CATEGORY = "DEFAULT";
 

--- a/feature/org.wso2.carbon.extension.identity.authenticator.passwordpolicy.feature/pom.xml
+++ b/feature/org.wso2.carbon.extension.identity.authenticator.passwordpolicy.feature/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.passwordpolicy</artifactId>
-        <version>1.0.30-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.extension.identity.authenticator.passwordpolicy.feature</artifactId>
-    <version>1.0.30-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - Password Policy - Server Feature</name>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.passwordpolicy</artifactId>
-    <version>1.0.30-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - Password Policy</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
With is 7.0, the `Password Expiry` feature will be available in the pack by default. Since the Password Expiry connector will be bumped by a major version with a deprecated tag added to the connector name. 

Issue : https://github.com/wso2/product-is/issues/17735