### PR TITLE
Enable support to store last password update time in nanoseconds

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
@@ -67,6 +67,13 @@ public class PasswordPolicyConstants {
             "Number of days before the password expiry that the users should be reminded of password expiry";
     public static final int CONNECTOR_CONFIG_PRIOR_NOTICE_TIME_IN_DAYS_DEFAULT_VALUE = 0;
 
+    public static final String CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS = "passwordExpiry.storeTimeAsNanoseconds";
+    public static final String CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS_DISPLAYED_NAME =
+            "Store Update Time As Nanoseconds";
+    public static final String CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS_DESCRIPTION =
+            "Store the last password update time in nanoseconds";
+    public static final boolean CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS_DEFAULT_VALUE = false;
+
     public static final String LOGIN_STANDARD_PAGE = "login.do";
     public static final String PASSWORD_RESET_ENFORCER_PAGE = "pwd-reset.jsp";
     public static final String PASSWORD_HISTORY_VIOLATION_ERROR_CODE = "22001";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
@@ -52,6 +52,7 @@ public class PasswordPolicyUtils {
         properties.add(PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS);
         properties.add(PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS);
         properties.add(PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS);
+        properties.add(PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS);
         return properties.toArray(new String[properties.size()]);
     }
 

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordChangeHandlerTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordChangeHandlerTest.java
@@ -503,7 +503,7 @@ public class PasswordChangeHandlerTest {
     @Test
     public void testGetPropertyNameMapping() {
         Map<String, String> propertyNameMapping = passwordChangeHandler.getPropertyNameMapping();
-        Assert.assertEquals(propertyNameMapping.size(), 3);
+        Assert.assertEquals(propertyNameMapping.size(), 4);
         Assert.assertEquals(
                 propertyNameMapping.get(PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS),
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS_DISPLAYED_NAME
@@ -516,12 +516,16 @@ public class PasswordChangeHandlerTest {
                 propertyNameMapping.get(PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS),
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS_DISPLAYED_NAME
         );
+        Assert.assertEquals(
+                propertyNameMapping.get(PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS),
+                PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS_DISPLAYED_NAME
+        );
     }
 
     @Test
     public void testGetPropertyDescriptionMapping() {
         Map<String, String> propertyDescriptionMapping = passwordChangeHandler.getPropertyDescriptionMapping();
-        Assert.assertEquals(propertyDescriptionMapping.size(), 3);
+        Assert.assertEquals(propertyDescriptionMapping.size(), 4);
         Assert.assertEquals(
                 propertyDescriptionMapping.get(PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS),
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS_DESCRIPTION
@@ -534,15 +538,20 @@ public class PasswordChangeHandlerTest {
                 propertyDescriptionMapping.get(PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS),
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS_DESCRIPTION
         );
+        Assert.assertEquals(
+                propertyDescriptionMapping.get(PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS),
+                PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS_DESCRIPTION
+        );
     }
 
     @Test
     public void testGetPropertyNames() {
         String[] propertyNames = passwordChangeHandler.getPropertyNames();
-        Assert.assertEquals(propertyNames.length, 3);
+        Assert.assertEquals(propertyNames.length, 4);
         Assert.assertEquals(propertyNames[0], PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS);
         Assert.assertEquals(propertyNames[1], PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS);
         Assert.assertEquals(propertyNames[2], PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS);
+        Assert.assertEquals(propertyNames[3], PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS);
     }
 
     @Test
@@ -555,6 +564,8 @@ public class PasswordChangeHandlerTest {
                 PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS)).thenReturn("true");
         when(PasswordPolicyUtils.getIdentityEventProperty(TENANT_DOMAIN,
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS)).thenReturn("2");
+        when(PasswordPolicyUtils.getIdentityEventProperty(TENANT_DOMAIN,
+                PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS)).thenReturn("false");
 
         ModuleConfiguration moduleConfiguration = mock(ModuleConfiguration.class);
         Whitebox.setInternalState(passwordChangeHandler, "configs", moduleConfiguration);
@@ -563,7 +574,7 @@ public class PasswordChangeHandlerTest {
         when(moduleConfiguration.getModuleProperties()).thenReturn(moduleProperties);
 
         Properties defaultPropertyValues = passwordChangeHandler.getDefaultPropertyValues(TENANT_DOMAIN);
-        Assert.assertEquals(defaultPropertyValues.size(), 3);
+        Assert.assertEquals(defaultPropertyValues.size(), 4);
         Assert.assertEquals(
                 defaultPropertyValues.get(PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS),
                 "30"
@@ -575,6 +586,10 @@ public class PasswordChangeHandlerTest {
         Assert.assertEquals(
                 defaultPropertyValues.get(PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS),
                 "2"
+        );
+        Assert.assertEquals(
+                defaultPropertyValues.get(PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS),
+                "false"
         );
     }
 

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordPolicyUtilsTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordPolicyUtilsTest.java
@@ -47,12 +47,14 @@ public class PasswordPolicyUtilsTest {
 
         String[] passwordExpiryPropertyNames = PasswordPolicyUtils.getPasswordExpiryPropertyNames();
 
-        Assert.assertEquals(passwordExpiryPropertyNames.length, 3);
+        Assert.assertEquals(passwordExpiryPropertyNames.length, 4);
         Assert.assertEquals(passwordExpiryPropertyNames[0],
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS);
         Assert.assertEquals(passwordExpiryPropertyNames[1],
                 PasswordPolicyConstants.CONNECTOR_CONFIG_ENABLE_EMAIL_NOTIFICATIONS);
         Assert.assertEquals(passwordExpiryPropertyNames[2],
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PRIOR_REMINDER_TIME_IN_DAYS);
+        Assert.assertEquals(passwordExpiryPropertyNames[3],
+                PasswordPolicyConstants.CONNECTOR_CONFIG_STORE_TIME_AS_NANOSECONDS);
     }
 }


### PR DESCRIPTION
The last password update time was always being stored as milliseconds. With this PR, the update time can be stored in nanoseconds. In order to cater this requirement, a new event property is introduced for `passwordExpiry` event handler. By default, the time will be stored in milliseconds. By enabling this property as in [1], the time can be stored as nanoseconds.

[1]
```
storeTimeAsNanoseconds= true
```

Related issue:
- https://github.com/wso2/product-is/issues/20800