### PR TITLE
Enable Windows FileTime comparison support for AD userstore

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
@@ -78,6 +78,15 @@ public class PasswordPolicyConstants {
     public static final String PASSWORD_EXPIRED_ERROR_MESSAGE = "Password has expired";
     public static final String PASSWORD_EXPIRY_IN_DAYS_DEFAULT_VALUE = "30";
 
+    // UserStore based Identity Datastore constants.
+    public static final String USER_OPERATION_EVENT_LISTENER_TYPE = "org.wso2.carbon.user.core.listener" +
+            ".UserOperationEventListener";
+    public static final String DATA_STORE_PROPERTY_NAME = "Data.Store";
+
+    // Time conversion constants.
+    public static final long WINDOWS_EPOCH_DIFF = 11644473600000L;
+    public static final long HUNDREDS_OF_NANOSECONDS = 10000L;
+
     private PasswordPolicyConstants() {      // To prevent instantiation
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
@@ -128,6 +128,12 @@ public class PasswordPolicyUtils {
         return propertyValue;
     }
 
+    /**
+     * Check whether the user store is based on identity data store.
+     *
+     * @return true if the user store is based on identity data store.
+     * @throws AuthenticationFailedException if an error occurs while initializing the UserStoreBasedIdentityDataStore.
+     */
     public static boolean isUserStoreBasedIdentityDataStore() throws AuthenticationFailedException {
 
         try {
@@ -142,12 +148,24 @@ public class PasswordPolicyUtils {
         }
     }
 
+    /**
+     * Check whether the user store is based on Active Directory.
+     *
+     * @param userStoreManager The user store manager.
+     * @return true if the user store is based on Active Directory.
+     */
     public static boolean isActiveDirectoryUserStore(UserStoreManager userStoreManager) {
 
         return userStoreManager instanceof UniqueIDJDBCUserStoreManager
                 && userStoreManager.getSecondaryUserStoreManager() instanceof UniqueIDActiveDirectoryUserStoreManager;
     }
 
+    /**
+     * Convert Windows file time to Unix time.
+     *
+     * @param windowsFileTime Windows file time.
+     * @return Unix time.
+     */
     public static String convertWindowsFileTimeToUnixTime(String windowsFileTime) {
 
         long fileTime = Long.parseLong(windowsFileTime);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
@@ -141,7 +141,7 @@ public class PasswordPolicyUtils {
                             IdentityStoreEventListener.class.getName()).getProperties()
                     .get(DATA_STORE_PROPERTY_NAME).toString();
             Class clazz = Class.forName(storeClassName.trim());
-            UserIdentityDataStore identityDataStore = (UserIdentityDataStore) clazz.newInstance();
+            Object identityDataStore = clazz.newInstance();
             return identityDataStore instanceof UserStoreBasedIdentityDataStore;
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
             throw new AuthenticationFailedException("Error while initializing the UserStoreBasedIdentityDataStore", e);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyUtils.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.identity.event.IdentityEventConfigBuilder;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.bean.ModuleConfiguration;
 import org.wso2.carbon.identity.governance.listener.IdentityStoreEventListener;
-import org.wso2.carbon.identity.governance.store.UserIdentityDataStore;
 import org.wso2.carbon.identity.governance.store.UserStoreBasedIdentityDataStore;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -161,10 +160,27 @@ public class PasswordPolicyUtils {
     }
 
     /**
-     * Convert Windows file time to Unix time.
+     * Converts a Windows FileTime string to Unix time in milliseconds.
      *
-     * @param windowsFileTime Windows file time.
-     * @return Unix time.
+     * Windows FileTime is a 64-bit value representing the number of 100-nanosecond
+     * intervals since January 1, 1601 (UTC).
+     *
+     * The conversion to Unix time (milliseconds since January 1, 1970, UTC) involves two steps:
+     *
+     * 1. Convert the Windows FileTime value from 100-nanosecond intervals to milliseconds:
+     *    - This is done by dividing the FileTime value by 10,000 (HUNDREDS_OF_NANOSECONDS).
+     *    - This converts the FileTime value from 100-nanosecond intervals to milliseconds.
+     *
+     * 2. Adjust for the difference in epoch start dates between Windows and Unix:
+     *    - Windows epoch starts on January 1, 1601, while Unix epoch starts on January 1, 1970.
+     *    - The difference between these two epochs is 11644473600000 milliseconds (WINDOWS_EPOCH_DIFF).
+     *    - Subtracting this value aligns the converted milliseconds with the Unix epoch.
+     *
+     * The resulting value represents the number of milliseconds since the Unix epoch,
+     * which is returned as a string.
+     *
+     * @param windowsFileTime A string representing the Windows FileTime to be converted.
+     * @return A string representing the Unix time in milliseconds.
      */
     public static String convertWindowsFileTimeToUnixTime(String windowsFileTime) {
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
@@ -276,6 +276,7 @@ public class PasswordResetEnforcer extends AbstractApplicationAuthenticator
             throw new AuthenticationFailedException("Error occurred while loading user claim - " + claimURI, e);
         }
 
+        // Check if the Identity datastore is set to Active Directory and do the conversion accordingly.
         if (isUserStoreBasedIdentityDataStore() && isActiveDirectoryUserStore(userStoreManager)) {
             passwordLastChangedTime = convertWindowsFileTimeToUnixTime(passwordLastChangedTime);
         }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
@@ -53,6 +53,9 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import static org.wso2.carbon.identity.policy.password.PasswordPolicyUtils.convertWindowsFileTimeToUnixTime;
+import static org.wso2.carbon.identity.policy.password.PasswordPolicyUtils.isActiveDirectoryUserStore;
+import static org.wso2.carbon.identity.policy.password.PasswordPolicyUtils.isUserStoreBasedIdentityDataStore;
 
 /**
  * this connector must only be present in an authentication step, where the user
@@ -271,6 +274,10 @@ public class PasswordResetEnforcer extends AbstractApplicationAuthenticator
             }
         } catch (UserStoreException e) {
             throw new AuthenticationFailedException("Error occurred while loading user claim - " + claimURI, e);
+        }
+
+        if (isUserStoreBasedIdentityDataStore() && isActiveDirectoryUserStore(userStoreManager)) {
+            passwordLastChangedTime = convertWindowsFileTimeToUnixTime(passwordLastChangedTime);
         }
 
         long passwordChangedTime = 0;

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordResetEnforcerTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordResetEnforcerTest.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.policy.password.PasswordPolicyConstants;
+import org.wso2.carbon.identity.policy.password.PasswordPolicyUtils;
 import org.wso2.carbon.identity.policy.password.PasswordResetEnforcer;
 import org.wso2.carbon.identity.policy.password.internal.PasswordPolicyDataHolder;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -74,7 +75,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @PrepareForTest({IdentityTenantUtil.class, ConfigurationFacade.class, FrameworkUtils.class, CarbonUtils.class,
-        IdentityProviderManager.class})
+        IdentityProviderManager.class, PasswordPolicyUtils.class})
 public class PasswordResetEnforcerTest {
     private PasswordResetEnforcer passwordResetEnforcer;
 
@@ -238,6 +239,7 @@ public class PasswordResetEnforcerTest {
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testInitiateAuthRequestWithException() throws Exception {
         mockStatic(IdentityTenantUtil.class);
+        mockStatic(PasswordPolicyUtils.class);
 
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
@@ -247,6 +249,8 @@ public class PasswordResetEnforcerTest {
         AuthenticatedUser user = AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier("admin");
         when(stepConfig.getAuthenticatedAutenticator()).thenReturn(authenticatorConfig);
         when(authenticatorConfig.getApplicationAuthenticator()).thenReturn(applicationAuthenticator);
+        when(PasswordPolicyUtils.isUserStoreBasedIdentityDataStore()).thenReturn(false);
+        when(PasswordPolicyUtils.isActiveDirectoryUserStore((UserStoreManager) anyObject())).thenReturn(false);
         when(Whitebox.invokeMethod(passwordResetEnforcer, "initiateAuthRequest",
                 httpServletResponse, context, ""))
                 .thenReturn(user);
@@ -260,6 +264,7 @@ public class PasswordResetEnforcerTest {
     @Test
     public void testInitiateAuthRequestForFederatedUser() throws Exception {
         mockStatic(IdentityTenantUtil.class);
+        mockStatic(PasswordPolicyUtils.class);
 
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
@@ -270,6 +275,8 @@ public class PasswordResetEnforcerTest {
         when(stepConfig.getAuthenticatedAutenticator()).thenReturn(authenticatorConfig);
         when(authenticatorConfig.getApplicationAuthenticator()).thenReturn(applicationAuthenticator);
         when(stepConfig.getAuthenticatedUser()).thenReturn(user);
+        when(PasswordPolicyUtils.isUserStoreBasedIdentityDataStore()).thenReturn(false);
+        when(PasswordPolicyUtils.isActiveDirectoryUserStore((UserStoreManager) anyObject())).thenReturn(false);
 
         AuthenticatorFlowStatus status = Whitebox
                 .invokeMethod(passwordResetEnforcer, "initiateAuthRequest",
@@ -284,6 +291,7 @@ public class PasswordResetEnforcerTest {
         mockStatic(FrameworkUtils.class);
         mockStatic(CarbonUtils.class);
         mockStatic(IdentityProviderManager.class);
+        mockStatic(PasswordPolicyUtils.class);
 
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
@@ -313,6 +321,8 @@ public class PasswordResetEnforcerTest {
                 context.getCallerSessionKey(), context.getContextIdentifier())).thenReturn(null);
         when(IdentityProviderManager.getInstance()).thenReturn(identityProviderManager);
         when(identityProviderManager.getResidentIdP("carbon.super")).thenReturn(null);
+        when(PasswordPolicyUtils.isUserStoreBasedIdentityDataStore()).thenReturn(false);
+        when(PasswordPolicyUtils.isActiveDirectoryUserStore((UserStoreManager) anyObject())).thenReturn(false);
 
         AuthenticatorFlowStatus status = Whitebox.invokeMethod(passwordResetEnforcer, "initiateAuthRequest",
                 httpServletResponse, context, "");
@@ -328,6 +338,7 @@ public class PasswordResetEnforcerTest {
         mockStatic(FrameworkUtils.class);
         mockStatic(CarbonUtils.class);
         mockStatic(IdentityProviderManager.class);
+        mockStatic(PasswordPolicyUtils.class);
 
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getBootstrapRealmConfiguration()).thenReturn(realmConfiguration);
@@ -362,6 +373,8 @@ public class PasswordResetEnforcerTest {
         when(context.isRetrying()).thenReturn(true);
         when(IdentityProviderManager.getInstance()).thenReturn(identityProviderManager);
         when(identityProviderManager.getResidentIdP("carbon.super")).thenReturn(null);
+        when(PasswordPolicyUtils.isUserStoreBasedIdentityDataStore()).thenReturn(false);
+        when(PasswordPolicyUtils.isActiveDirectoryUserStore((UserStoreManager) anyObject())).thenReturn(false);
 
         AuthenticatorFlowStatus status = Whitebox
                 .invokeMethod(passwordResetEnforcer, "initiateAuthRequest",

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <carbon.identity.framework.version>5.11.109</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.1.7</carbon.identity.governance.version>
         <commons-logging.version>4.4.23</commons-logging.version>
-        <carbon.kernel.version>4.4.23</carbon.kernel.version>
+        <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <testng.version>6.9.10</testng.version>
         <jacoco.version>0.7.9</jacoco.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>


### PR DESCRIPTION
When UserStoreBasedIdentityDataStore is enabled and Active Directory is chosen as the UserStore, when storing the last password update time to the Pwd-Last-Set attribute, it will be stored as Windows FileTime which represents nanoseconds counted from year 1601. So, when the value of the last password update is retrieved through the userstore manager, the same value is returned. But in the PasswordResetEnforcer,  we only had the capability to compare the time using milliseconds. Hence, during the the calculation of days, incorrect values will be returned. 

This PR introduces the mechanism to address this bug.

Related issue:
- https://github.com/wso2/product-is/issues/20800
