### PR TITLE
Remove is 7.0 from supported products

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -10,14 +10,13 @@
         {
             "tagName": "v2.0.4",
             "products": [
-                "IS 7.0.0",
                 "IS 6.1.0"
             ]
         },
         {
             "tagName": "v2.0.0",
             "products": [
-                "IS 7.0.0"
+                "IS 6.1.0"
             ]
         },
         {


### PR DESCRIPTION
## Purpose
> Since Password Expiration is now part of the Password Validation settings in IS7 and is packed by default, this connector is not needed for IS 7.  
