### PR TITLE
Update password policy connector to compatible with IS 7.0.0

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>org.wso2.carbon.identity.password.history</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.password.expiry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
         </dependency>
@@ -161,7 +165,7 @@
                             org.wso2.carbon.identity.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.apache.commons.logging.*; version="1.0.4",
                             org.osgi.framework,
-                            org.wso2.carbon.identity.application.authentication.framework.*,
+                            org.wso2.carbon.identity.application.authentication.framework.*; version="${carbon.identity.package.import.version.range},
                             javax.servlet,
                             javax.servlet.http,
                             org.wso2.carbon.databridge.commons; version="${carbon.analytics-common.version}",

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordChangeHandler.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordChangeHandler.java
@@ -237,9 +237,6 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
             org.wso2.carbon.user.api.UserStoreException, AuthenticationFailedException {
 
         String passwordLastChangedTime = getPasswordLastChangeTime(tenantDomain, tenantAwareUsername, userStoreManager);
-        int passwordExpiryInDays =  getPasswordExpiryInDaysConfig(tenantDomain);
-        String userId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(tenantAwareUsername);
-
         long passwordChangedTime = 0;
         if (passwordLastChangedTime != null) {
             passwordChangedTime = Long.parseLong(passwordLastChangedTime);
@@ -256,7 +253,7 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
             log.debug("User: " + tenantAwareUsername + " password is updated before " + daysDifference + " Days");
         }
         return PasswordPolicyUtils.isPasswordExpiredForUser(tenantDomain, daysDifference, passwordLastChangedTime,
-                userId, userStoreManager);
+                tenantAwareUsername, userStoreManager);
     }
 
     /**
@@ -288,39 +285,6 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
         }
 
         return passwordLastChangedTime;
-    }
-
-    /**
-     * get password expiry in days configured value.
-     * @param tenantDomain user tenant domain
-     * @return password expiry days as a int
-     */
-    private int getPasswordExpiryInDaysConfig(String tenantDomain) {
-
-        String passwordExpiryInDaysConfiguredValue = null;
-        try {
-            passwordExpiryInDaysConfiguredValue = PasswordPolicyUtils.getResidentIdpProperty(tenantDomain,
-                    PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS);
-        } catch (AuthenticationFailedException e) {
-            log.warn("Authentication Exception occurred while reading password expiry residentIdp property");
-        }
-
-        if (passwordExpiryInDaysConfiguredValue == null || StringUtils.isEmpty(passwordExpiryInDaysConfiguredValue)) {
-            String passwordExpiryInDaysIdentityEventProperty = this.configs.getModuleProperties().getProperty(
-                    PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS);
-            if (StringUtils.isNotEmpty(passwordExpiryInDaysIdentityEventProperty)) {
-                passwordExpiryInDaysConfiguredValue = passwordExpiryInDaysIdentityEventProperty;
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Password expiry in days configuration can not be fetched or null. Hence using the " +
-                            "default: " + PasswordPolicyConstants.PASSWORD_EXPIRY_IN_DAYS_DEFAULT_VALUE + " days");
-                }
-                passwordExpiryInDaysConfiguredValue =
-                        PasswordPolicyConstants.PASSWORD_EXPIRY_IN_DAYS_DEFAULT_VALUE;
-            }
-
-        }
-        return Integer.parseInt(passwordExpiryInDaysConfiguredValue);
     }
 
     /**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
@@ -83,6 +83,10 @@ public class PasswordPolicyConstants {
             ".UserOperationEventListener";
     public static final String DATA_STORE_PROPERTY_NAME = "Data.Store";
 
+    public static final String CONNECTOR_CONFIG_NAME = "passwordExpiry";
+    public static final String PASSWORD_EXPIRY_RULES_PREFIX = "passwordExpiry.rule";
+    public static final String CONNECTOR_CONFIG_SKIP_IF_NO_APPLICABLE_RULES =
+            "passwordExpiry.skipIfNoApplicableRules";
     // Time conversion constants.
     public static final long WINDOWS_EPOCH_DIFF = 11644473600000L;
     public static final long HUNDREDS_OF_NANOSECONDS = 10000L;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
@@ -258,10 +258,9 @@ public class PasswordResetEnforcer extends AbstractApplicationAuthenticator
             RealmService realmService = IdentityTenantUtil.getRealmService();
             userRealm = realmService.getTenantUserRealm(tenantId);
             userStoreManager = (UserStoreManager) userRealm.getUserStoreManager();
-            String userId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(tenantAwareUsername);
 
-        String passwordLastChangedTime;
-        String claimURI = PasswordPolicyConstants.LAST_CREDENTIAL_UPDATE_TIMESTAMP_CLAIM;
+            String passwordLastChangedTime;
+            String claimURI = PasswordPolicyConstants.LAST_CREDENTIAL_UPDATE_TIMESTAMP_CLAIM;
             try {
                 passwordLastChangedTime = getLastPasswordUpdateTime(userStoreManager, claimURI, tenantAwareUsername);
                 if (passwordLastChangedTime == null) {
@@ -295,7 +294,7 @@ public class PasswordResetEnforcer extends AbstractApplicationAuthenticator
             }
 
             return PasswordPolicyUtils.isPasswordExpiredForUser(tenantDomain, daysDifference, passwordLastChangedTime,
-                    userId, userStoreManager);
+                    tenantAwareUsername, userStoreManager);
         } catch (UserStoreException e) {
             throw new AuthenticationFailedException("Error occurred while loading user manager from user realm", e);
         }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.policy.password;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,31 +28,21 @@ import org.wso2.carbon.identity.application.authentication.framework.config.Conf
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
-import org.wso2.carbon.identity.application.authentication.framework.exception.PostAuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.mgt.policy.PolicyViolationException;
 import org.wso2.carbon.identity.password.history.exeption.IdentityPasswordHistoryException;
-import org.wso2.carbon.identity.policy.password.internal.PasswordPolicyDataHolder;
-import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
-import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
-import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.user.api.ClaimManager;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
-
-import org.wso2.carbon.identity.password.expiry.models.PasswordExpiryRuleAttributeEnum;
-import org.wso2.carbon.identity.password.expiry.models.PasswordExpiryRuleOperatorEnum;
-import org.wso2.carbon.identity.password.expiry.models.PasswordExpiryRule;
 
 import java.io.IOException;
 import java.net.URLEncoder;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/internal/PasswordPolicyDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/internal/PasswordPolicyDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.policy.password.internal;
 
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 
 /**
  * The data holder for the password policy.
@@ -27,6 +28,7 @@ public class PasswordPolicyDataHolder {
     private static PasswordPolicyDataHolder instance;
 
     private IdentityGovernanceService identityGovernanceService;
+    private RoleManagementService roleManagementService;
 
     private PasswordPolicyDataHolder() {     // Prevent instantiation
     }
@@ -49,5 +51,15 @@ public class PasswordPolicyDataHolder {
 
     public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
         this.identityGovernanceService = identityGovernanceService;
+    }
+
+    public RoleManagementService getRoleManagementService() {
+
+        return roleManagementService;
+    }
+
+    public void setRoleManagementService(RoleManagementService roleManagementService) {
+
+        this.roleManagementService = roleManagementService;
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/internal/PasswordPolicyServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/internal/PasswordPolicyServiceComponent.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
 import org.wso2.carbon.identity.policy.password.PasswordChangeHandler;
 import org.wso2.carbon.identity.policy.password.PasswordResetEnforcer;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 
 @Component(
         name = "org.wso2.carbon.identity.policy.password.component",
@@ -88,5 +89,22 @@ public class PasswordPolicyServiceComponent {
 
     protected void unsetIdentityGovernanceService(IdentityGovernanceService idpManager) {
         PasswordPolicyDataHolder.getInstance().setIdentityGovernanceService(null);
+    }
+
+    @Reference(
+            name = "role.management.service",
+            service = RoleManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRoleManagementService"
+    )
+    protected void setRoleManagementService(RoleManagementService roleManagementService) {
+
+        PasswordPolicyDataHolder.getInstance().setRoleManagementService(roleManagementService);
+    }
+
+    protected void unsetRoleManagementService(RoleManagementService roleManagementService) {
+
+        PasswordPolicyDataHolder.getInstance().setRoleManagementService(null);
     }
 }

--- a/component/authenticator/src/main/resources/pwd-reset.jsp
+++ b/component/authenticator/src/main/resources/pwd-reset.jsp
@@ -25,9 +25,13 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.TenantDataManager" %>
 <%@ page import="java.io.File" %>
+<%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
 <%@ include file="includes/localize.jsp" %>
 <jsp:directive.include file="includes/init-url.jsp"/>
+
+<%-- Branding Preferences --%>
+<jsp:directive.include file="includes/branding-preferences.jsp"/>
 
 <%
     request.getSession().invalidate();
@@ -62,13 +66,13 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 
-<body>
-    <main class="center-segment">
-        <div class="ui container medium center aligned middle aligned">
+<body class="login-portal layout authentication-portal-layout">
+    <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
+        <layout:component componentName="ProductHeader">
             <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
@@ -76,9 +80,10 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
-
+        </layout:component>
+        <layout:component componentName="MainSection">
             <div class="ui segment">
                 <!-- content -->
                 <h3 class="ui header">
@@ -133,18 +138,20 @@
                     </form>
                 </div>
             </div>
-        </div>
-    </main>
-    <!-- /content/body -->
-    <!-- product-footer -->
-    <%
-        File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
-        if (productFooterFile.exists()) {
-    %>
-        <jsp:include page="extensions/product-footer.jsp"/>
-    <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
-    <% } %>
+        </layout:component>
+        <!-- /content/body -->
+        <!-- product-footer -->
+        <layout:component componentName="ProductFooter">
+            <%
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
+            %>
+                <jsp:include page="extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="includes/product-footer.jsp"/>
+            <% } %>
+        </layout:component>
+    </layout:main>
 
     <!-- footer -->
     <%
@@ -153,7 +160,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 </body>
 </html>

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordChangeHandlerTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordChangeHandlerTest.java
@@ -57,6 +57,9 @@ import java.util.Properties;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -322,11 +325,11 @@ public class PasswordChangeHandlerTest {
         when(MultitenantUtils.getTenantAwareUsername(USERNAME)).thenReturn(USERNAME);
         when(PasswordPolicyUtils.getResidentIdpProperty(TENANT_DOMAIN,
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS)).thenReturn("20");
-
+        when(PasswordPolicyUtils.isPasswordExpiredForUser(anyString(), anyDouble(), anyString(),
+                anyString(), anyObject() )).thenReturn(true);
         Map<String, String> claimValueMap = new HashMap<>();
         claimValueMap.put(PasswordPolicyConstants.LAST_CREDENTIAL_UPDATE_TIMESTAMP_CLAIM,"1672559229000");
         String[] claimURIs = new String[]{PasswordPolicyConstants.LAST_CREDENTIAL_UPDATE_TIMESTAMP_CLAIM};
-
         when(userStoreManager.getUserClaimValues(USERNAME, claimURIs, null)).thenReturn(claimValueMap);
         try {
             passwordChangeHandler.handleEvent(event);
@@ -390,6 +393,8 @@ public class PasswordChangeHandlerTest {
         when(MultitenantUtils.getTenantAwareUsername(USERNAME)).thenReturn(USERNAME);
         when(PasswordPolicyUtils.getResidentIdpProperty(TENANT_DOMAIN,
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS)).thenReturn("20");
+        when(PasswordPolicyUtils.isPasswordExpiredForUser(anyString(), anyDouble(), anyString(),
+                anyString(), anyObject() )).thenReturn(true);
         when(IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
@@ -428,6 +433,8 @@ public class PasswordChangeHandlerTest {
         when(MultitenantUtils.getTenantAwareUsername(USERNAME)).thenReturn(USERNAME);
         when(PasswordPolicyUtils.getResidentIdpProperty(TENANT_DOMAIN,
                 PasswordPolicyConstants.CONNECTOR_CONFIG_PASSWORD_EXPIRY_IN_DAYS)).thenReturn("20");
+        when(PasswordPolicyUtils.isPasswordExpiredForUser(anyString(), anyDouble(), anyString(),
+                anyString(), anyObject() )).thenReturn(true);
         when(IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
         when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
         when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordResetEnforcerTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordResetEnforcerTest.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.policy.password.PasswordPolicyConstants;
 import org.wso2.carbon.identity.policy.password.PasswordPolicyUtils;
 import org.wso2.carbon.identity.policy.password.PasswordResetEnforcer;
 import org.wso2.carbon.identity.policy.password.internal.PasswordPolicyDataHolder;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.api.Claim;
 import  org.wso2.carbon.user.core.claim.ClaimManager;
@@ -130,11 +131,15 @@ public class PasswordResetEnforcerTest {
     @Mock
     private IdentityProviderManager identityProviderManager;
 
+    @Mock
+    private RoleManagementService roleManagementService;
+
     @BeforeMethod
     public void setUp() {
         passwordResetEnforcer = new PasswordResetEnforcer();
         initMocks(this);
         PasswordPolicyDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
+        PasswordPolicyDataHolder.getInstance().setRoleManagementService(roleManagementService);
     }
 
     @Test

--- a/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordResetEnforcerTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/extension/identity/authenticator/passwordpolicy/test/PasswordResetEnforcerTest.java
@@ -29,6 +29,7 @@ import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
@@ -55,6 +56,7 @@ import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -68,6 +70,8 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyDouble;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -114,6 +118,9 @@ public class PasswordResetEnforcerTest {
     private UserStoreManager userStoreManager;
 
     @Mock
+    private AbstractUserStoreManager abstractUserStoreManager;
+
+    @Mock
     private ClaimManager claimManager;
 
     @Mock
@@ -134,12 +141,24 @@ public class PasswordResetEnforcerTest {
     @Mock
     private RoleManagementService roleManagementService;
 
+    static {
+        // Set the CARBON_HOME system property
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+    }
+
     @BeforeMethod
-    public void setUp() {
+    public void setUp() throws Exception{
         passwordResetEnforcer = new PasswordResetEnforcer();
         initMocks(this);
         PasswordPolicyDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
         PasswordPolicyDataHolder.getInstance().setRoleManagementService(roleManagementService);
+
+        // Ensure that the mocks are correctly set up
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
     }
 
     @Test
@@ -328,6 +347,8 @@ public class PasswordResetEnforcerTest {
         when(identityProviderManager.getResidentIdP("carbon.super")).thenReturn(null);
         when(PasswordPolicyUtils.isUserStoreBasedIdentityDataStore()).thenReturn(false);
         when(PasswordPolicyUtils.isActiveDirectoryUserStore((UserStoreManager) anyObject())).thenReturn(false);
+        when(PasswordPolicyUtils.isPasswordExpiredForUser(anyString(), anyDouble(), anyString(),
+                anyString(), anyObject() )).thenReturn(true);
 
         AuthenticatorFlowStatus status = Whitebox.invokeMethod(passwordResetEnforcer, "initiateAuthRequest",
                 httpServletResponse, context, "");
@@ -380,6 +401,8 @@ public class PasswordResetEnforcerTest {
         when(identityProviderManager.getResidentIdP("carbon.super")).thenReturn(null);
         when(PasswordPolicyUtils.isUserStoreBasedIdentityDataStore()).thenReturn(false);
         when(PasswordPolicyUtils.isActiveDirectoryUserStore((UserStoreManager) anyObject())).thenReturn(false);
+        when(PasswordPolicyUtils.isPasswordExpiredForUser(anyString(), anyDouble(), anyString(),
+                anyString(), anyObject() )).thenReturn(true);
 
         AuthenticatorFlowStatus status = Whitebox
                 .invokeMethod(passwordResetEnforcer, "initiateAuthRequest",

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
                 <version>${carbon.identity.governance.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.password.expiry</artifactId>
+                <version>${carbon.identity.governance.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${org.apache.felix.scr.ds.annotations.version}</version>
@@ -218,8 +223,8 @@
                 <version>2.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -317,8 +322,8 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.framework.version>5.11.109</carbon.identity.framework.version>
-        <carbon.identity.governance.version>1.1.7</carbon.identity.governance.version>
+        <carbon.identity.framework.version>7.7.28</carbon.identity.framework.version>
+        <carbon.identity.governance.version>1.11.20</carbon.identity.governance.version>
         <commons-logging.version>4.4.23</commons-logging.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <testng.version>6.9.10</testng.version>
@@ -330,7 +335,7 @@
         <carbon.analytics-common.version>5.1.31</carbon.analytics-common.version>
         <maven.scr.plugin.version>1.24.0</maven.scr.plugin.version>
         <org.apache.felix.scr.ds.annotations.version>1.2.8</org.apache.felix.scr.ds.annotations.version>
-        <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[5.0.0, 8.0.0)</carbon.identity.package.import.version.range>
         <org.apache.commons.logging.version>1.0.4</org.apache.commons.logging.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -306,8 +306,6 @@
         </pluginManagement>
     </build>
 
-
-
     <distributionManagement>
         <repository>
             <id>nexus-releases</id>
@@ -322,8 +320,8 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.framework.version>7.7.28</carbon.identity.framework.version>
-        <carbon.identity.governance.version>1.11.20</carbon.identity.governance.version>
+        <carbon.identity.framework.version>7.0.78</carbon.identity.framework.version>
+        <carbon.identity.governance.version>1.10.11</carbon.identity.governance.version>
         <commons-logging.version>4.4.23</commons-logging.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
## Purpose
- Need to onboard the password policy connector to IS 7.0.0

## Changes from this PR
- Bump the osgi service version ranges to compatible with IS 7.0.0
- Bump the framework and governance versions
- Change the pwd-reset.jsp to honor the brandings and new layout components
- Improve the password reset enforcer and password change handler to honor the rule based password policy expiry as well
- Fix the failed unit test cases
- Move the common logic to utils class


## Related issue
https://github.com/wso2/product-is/issues/21890