### PR TITLE
Fix password expiry check to use full username in event

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordChangeHandler.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordChangeHandler.java
@@ -59,7 +59,6 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
         if (PasswordPolicyConstants.PASSWORD_GRANT_POST_AUTHENTICATION_EVENT.equals(eventName)) {
             String tenantDomain = (String) event.getEventProperties()
                     .get(IdentityEventConstants.EventProperty.TENANT_DOMAIN);
-            String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
             boolean authenticationStatus = (boolean) event.getEventProperties().get(
                     PasswordPolicyConstants.AUTHENTICATION_STATUS);
 
@@ -68,7 +67,7 @@ public class PasswordChangeHandler extends AbstractEventHandler implements Ident
                     log.debug("Checking password validity of " + username);
                 }
                 try {
-                    if (isPasswordExpired(tenantDomain, tenantAwareUsername)) {
+                    if (isPasswordExpired(tenantDomain, username)) {
                         if (log.isDebugEnabled()) {
                             log.debug("User: " + username + " password is expired.");
                         }


### PR DESCRIPTION
### Fix redundant tenant-aware username conversion in password expiry check
#### Problem

In PasswordChangeHandler, when handling the `PASSWORD_GRANT_POST_AUTHENTICATION_EVENT`, the code was unnecessarily converting the username to a tenant-aware form using `MultitenantUtils.getTenantAwareUsername()` before passing it to i`sPasswordExpired()`.


// Before (redundant)
```
String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
if (isPasswordExpired(tenantDomain, tenantAwareUsername)) { ... }
```

#### Root Cause
The `PASSWORD_GRANT_POST_AUTHENTICATION_EVENT` is triggered from [PasswordGrantHandler#authenticateUserAtUserStore](https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/fdb34509a8762adfbf6ea6ef05450dffd63f1dca/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/PasswordGrantHandler.java#L177) with the USER_NAME event property set to userStoreQualifiedTenantAwareUserName. This value is derived from AuthenticatedUser#getDomainQualifiedUsername(), which is already a tenant-aware, userstore-domain-qualified username — it does not carry the @tenant.com suffix.

Calling `MultitenantUtils.getTenantAwareUsername()` on a username that is already in this form is redundant and can be unsafe: if the username contains an @ character that is not a tenant domain suffix (e.g., an email-format username qualified with a userstore domain such as PRIMARY/user@example.com), the conversion may incorrectly truncate the username, causing the password expiry lookup to fail or target the wrong user.

#### Fix
Remove the intermediate tenantAwareUsername variable and pass username directly to isPasswordExpired(), trusting the format of the value already set by the event publisher.
