### PR TITLE
Handle password expiry for shared users

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordPolicyConstants.java
@@ -42,6 +42,7 @@ public class PasswordPolicyConstants {
     public static final String PASSWORD_RESET_ERROR_MESSAGE = "passwordResetErrorMessage";
     public static final String PASSWORD_RESET_ERROR_KEY = "password.reset.error";
     public static final String PASSWORD_RESET_COMPLETE = "passwordResetComplete";
+    public static final String PASSWORD_EXPIRED_ERROR_KEY_PARAM = "&errorKey=Password.Expired";
 
     public static final String LAST_CREDENTIAL_UPDATE_TIMESTAMP_CLAIM =
             "http://wso2.org/claims/identity/lastPasswordUpdateTime";
@@ -86,6 +87,7 @@ public class PasswordPolicyConstants {
     public static final String PASSWORD_RESET_ENFORCER_PAGE = "pwd-reset.jsp";
     public static final String PASSWORD_HISTORY_VIOLATION_ERROR_CODE = "22001";
     public static final String LAST_FAILED_AUTHENTICATOR = "LastFailedAuthenticator";
+    public static final String RECOVERY_PORTAL_ERROR_PAGE = "/error.jsp";
 
     //password grant flow - password expiry validation constants
     public static final String PASSWORD_GRANT_POST_AUTHENTICATION_EVENT = "PASSWORD_GRANT_POST_AUTHENTICATION";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/policy/password/PasswordResetEnforcer.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.policy.password;
 
+import net.shibboleth.utilities.java.support.net.URLBuilder;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -247,26 +248,37 @@ public class PasswordResetEnforcer extends AbstractApplicationAuthenticator
                 }
                 // The password has expired or the password changed time is not set
                 try {
-                    // Creating the URL to which the user will be redirected
-                    String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL()
-                            .replace(PasswordPolicyConstants.LOGIN_STANDARD_PAGE,
-                                    PasswordPolicyConstants.PASSWORD_RESET_ENFORCER_PAGE);
-                    String queryParams = FrameworkUtils.getQueryStringWithFrameworkContextId(context.getQueryParams(),
-                            context.getCallerSessionKey(), context.getContextIdentifier());
-                    String retryParam = "";
-                    if (context.isRetrying()) {
-                        retryParam = "&authFailure=true" +
-                                "&authFailureMsg=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8.name());
-                    }
-                    String fullyQualifiedUsername = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername,
-                            tenantDomain);
-                    String encodedUrl =
-                            (loginPage + ("?" + queryParams
-                            + "&username=" + URLEncoder.encode(fullyQualifiedUsername, StandardCharsets.UTF_8.name())))
-                            + "&authenticators=" + getName() + ":" + PasswordPolicyConstants.AUTHENTICATOR_TYPE
-                            + retryParam;
+                    if (FrameworkUtils.getSharedUserIdentifiedInSequence(context).isPresent()) {
+                        // If the password expired user is a shared user, don't redirect to the password reset page.
+                        String errorUrl = ConfigurationFacade.getInstance().getAccountRecoveryEndpointPath() +
+                                PasswordPolicyConstants.RECOVERY_PORTAL_ERROR_PAGE;
+                        response.sendRedirect(FrameworkUtils.appendQueryParamsStringToUrl(errorUrl,
+                                PasswordPolicyConstants.PASSWORD_EXPIRED_ERROR_KEY_PARAM));
+                    } else {
+                        // Creating the URL to which the user will be redirected
+                        String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL()
+                                .replace(PasswordPolicyConstants.LOGIN_STANDARD_PAGE,
+                                        PasswordPolicyConstants.PASSWORD_RESET_ENFORCER_PAGE);
+                        String queryParams =
+                                FrameworkUtils.getQueryStringWithFrameworkContextId(context.getQueryParams(),
+                                        context.getCallerSessionKey(), context.getContextIdentifier());
+                        String retryParam = "";
+                        if (context.isRetrying()) {
+                            retryParam = "&authFailure=true" +
+                                    "&authFailureMsg=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8.name());
+                        }
+                        String fullyQualifiedUsername = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername,
+                                tenantDomain);
+                        String encodedUrl =
+                                (loginPage + ("?" + queryParams
+                                        + "&username=" +
+                                        URLEncoder.encode(fullyQualifiedUsername, StandardCharsets.UTF_8.name())))
+                                        + "&authenticators=" + getName() + ":" +
+                                        PasswordPolicyConstants.AUTHENTICATOR_TYPE
+                                        + retryParam;
 
-                    response.sendRedirect(encodedUrl);
+                        response.sendRedirect(encodedUrl);
+                    }
                 } catch (IOException e) {
                     throw new AuthenticationFailedException(e.getMessage(), e);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.framework.version>7.10.76</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.89</carbon.identity.framework.version>
         <carbon.identity.governance.version>1.11.31</carbon.identity.governance.version>
         <commons-logging.version>4.4.23</commons-logging.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>


### PR DESCRIPTION
## Purpose
This pr updates the password reset enforcer authenticator to handle shared users. If a password expired shared user is logging into a sub-organization, they will be redirected to an error page instead of the password reset page. 

### Related issue
- https://github.com/wso2/product-is/issues/27371